### PR TITLE
setup.py: Open README with utf-8 encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ del(os, sys)
 
 
 # Load text for long description
-with open('README.md') as f:
+with open('README.md', encoding='utf-8') as f:
     readme = f.read()
 
 


### PR DESCRIPTION
Otherwise the package can't be installed on Windows