### PR TITLE
Added methods to check if below sea-level points were considered sea …

### DIFF
--- a/docs/source/os_terrain_50.rst
+++ b/docs/source/os_terrain_50.rst
@@ -20,6 +20,12 @@ Accessing the data
 
 .. autofunction:: spacing
 
+Checking if points are sea or just below sea-level
+==================================================
+
+.. autofunction:: inland_below_sea_level
+
+.. autofunction:: is_sea
 
 Downloading the data
 ====================

--- a/nevis/__init__.py
+++ b/nevis/__init__.py
@@ -64,6 +64,8 @@ from ._os_terrain_50 import (    # noqa
     DataNotFoundError,
     download_os_terrain_50,
     gb,
+    inland_below_sea_level,
+    is_sea,
     spacing,
 )
 from ._interpolation import (   # noqa

--- a/nevis/_os_terrain_50.py
+++ b/nevis/_os_terrain_50.py
@@ -83,7 +83,7 @@ def gb(downsampling=None):
         if not os.path.isfile(not_sea_file_npy):
             raise DataNotFoundError(
                 'List of below sea-level inland points not found in'
-                ' {nevis._DIR_DATA}. Please call'
+                f' {nevis._DIR_DATA}. Please call'
                 ' nevis.download_os_terrain_50() to create this file.'
             )
 

--- a/nevis/_plot.py
+++ b/nevis/_plot.py
@@ -245,13 +245,15 @@ def plot(boundaries=None, labels=None, trajectory=None, points=None,
 
     # Show requested points
     if points is not None:
+        points = np.asarray(points)
+        alpha, ms, mw = (0.3, 4, 1) if len(points) > 20 else (1, 12, 2)
         x, y = meters2indices(points[:, 0], points[:, 1])
-        ax.plot(
-            x, y, 'x', color='#0000ff',
-            markeredgewidth=1, markersize=4, alpha=0.3)
+        ax.plot(x, y, 'x', color='#0000ff',
+                markeredgewidth=mw, markersize=ms, alpha=alpha)
 
     # Show trajectory
     if trajectory is not None:
+        trajectory = np.asarray(trajectory)
         x, y = meters2indices(trajectory[:, 0], trajectory[:, 1])
         ax.plot(
             x, y, 'o-', color='#000000',


### PR DESCRIPTION
…when the mask was generated and the sea slope was added.

@EricWay1024 this adds a method `is_sea` that accepts coordinates and tells you whether nevis thinks it's sea or not

Also a method `inland_below_sea_level` that returns coordinates for all grid squares below 0 but not considered sea.
This returns points in meters, but you can divide by 50 to get matrix indices.
Alternatively, we can expose the hidden method `inland_below_sea_level_indices` to return those directly.